### PR TITLE
Default substitution changes

### DIFF
--- a/config/sensor-pkg-a-c4001-esp32-s3.yaml
+++ b/config/sensor-pkg-a-c4001-esp32-s3.yaml
@@ -13,14 +13,14 @@ substitutions:
   co_temp_id: "temperature"
   co_offset: "0.0"
   co_sensitivity: "2.000e-9"
-  co_manufacture_date: "Unknown"
+  co_manufacture_date: "Not Set"
   co_serial_number: "111111111111111111"
   # Temperature Configuration
   temperature_offset: "0.0"
   # Humidity Configuration
   humidity_offset: "0.0"
   # CO₂ Configuration
-  co2_calibration_date: "Unknown"
+  co2_calibration_date: "Not Set"
   # Automatically controlled Vent
   vent_ha_entity: fan.vent_id
   vent_use_humidity: "true"

--- a/config/sensor-pkg-a-ld2410-esp32-s3.yaml
+++ b/config/sensor-pkg-a-ld2410-esp32-s3.yaml
@@ -13,14 +13,14 @@ substitutions:
   co_temp_id: "temperature"
   co_offset: "0.0"
   co_sensitivity: "2.000e-9"
-  co_manufacture_date: "Unknown"
+  co_manufacture_date: "Not Set"
   co_serial_number: "111111111111111111"
   # Temperature Configuration
   temperature_offset: "0.0"
   # Humidity Configuration
   humidity_offset: "0.0"
   # CO₂ Configuration
-  co2_calibration_date: "Unknown"
+  co2_calibration_date: "Not Set"
   # Automatically controlled Vent
   vent_ha_entity: fan.vent_id
   vent_use_humidity: "true"

--- a/config/sensor-pkg-a-ld2450-mtmz-esp32-s3.yaml
+++ b/config/sensor-pkg-a-ld2450-mtmz-esp32-s3.yaml
@@ -13,14 +13,14 @@ substitutions:
   co_temp_id: "temperature"
   co_offset: "0.0"
   co_sensitivity: "2.000e-9"
-  co_manufacture_date: "Unknown"
+  co_manufacture_date: "Not Set"
   co_serial_number: "111111111111111111"
   # Temperature Configuration
   temperature_offset: "0.0"
   # Humidity Configuration
   humidity_offset: "0.0"
   # CO₂ Configuration
-  co2_calibration_date: "Unknown"
+  co2_calibration_date: "Not Set"
   # Automatically controlled Vent
   vent_ha_entity: fan.vent_id
   vent_use_humidity: "true"

--- a/config/sensor-pkg-a-ld2450-stsz-esp32-s3.yaml
+++ b/config/sensor-pkg-a-ld2450-stsz-esp32-s3.yaml
@@ -13,14 +13,14 @@ substitutions:
   co_temp_id: "temperature"
   co_offset: "0.0"
   co_sensitivity: "2.000e-9"
-  co_manufacture_date: "Unknown"
+  co_manufacture_date: "Not Set"
   co_serial_number: "111111111111111111"
   # Temperature Configuration
   temperature_offset: "0.0"
   # Humidity Configuration
   humidity_offset: "0.0"
   # CO₂ Configuration
-  co2_calibration_date: "Unknown"
+  co2_calibration_date: "Not Set"
   # Automatically controlled Vent
   vent_ha_entity: fan.vent_id
   vent_use_humidity: "true"

--- a/config/sensor-pkg-b-c4001-esp32-s3.yaml
+++ b/config/sensor-pkg-b-c4001-esp32-s3.yaml
@@ -13,14 +13,14 @@ substitutions:
   co_temp_id: "temperature"
   co_offset: "0.0"
   co_sensitivity: "2.000e-9"
-  co_manufacture_date: "Unknown"
+  co_manufacture_date: "Not Set"
   co_serial_number: "111111111111111111"
   # Temperature Configuration
   temperature_offset: "0.0"
   # Humidity Configuration
   humidity_offset: "0.0"
   # CO₂ Configuration
-  co2_calibration_date: "Unknown"
+  co2_calibration_date: "Not Set"
   # Automatically controlled Vent
   vent_ha_entity: fan.vent_id
   vent_use_humidity: "true"

--- a/config/sensor-pkg-b-ld2410-esp32-s3.yaml
+++ b/config/sensor-pkg-b-ld2410-esp32-s3.yaml
@@ -13,14 +13,14 @@ substitutions:
   co_temp_id: "temperature"
   co_offset: "0.0"
   co_sensitivity: "2.000e-9"
-  co_manufacture_date: "Unknown"
+  co_manufacture_date: "Not Set"
   co_serial_number: "111111111111111111"
   # Temperature Configuration
   temperature_offset: "0.0"
   # Humidity Configuration
   humidity_offset: "0.0"
   # CO₂ Configuration
-  co2_calibration_date: "Unknown"
+  co2_calibration_date: "Not Set"
   # Automatically controlled Vent
   vent_ha_entity: fan.vent_id
   vent_use_humidity: "true"

--- a/config/sensor-pkg-b-ld2450-mtmz-esp32-s3.yaml
+++ b/config/sensor-pkg-b-ld2450-mtmz-esp32-s3.yaml
@@ -13,14 +13,14 @@ substitutions:
   co_temp_id: "temperature"
   co_offset: "0.0"
   co_sensitivity: "2.000e-9"
-  co_manufacture_date: "Unknown"
+  co_manufacture_date: "Not Set"
   co_serial_number: "111111111111111111"
   # Temperature Configuration
   temperature_offset: "0.0"
   # Humidity Configuration
   humidity_offset: "0.0"
   # CO₂ Configuration
-  co2_calibration_date: "Unknown"
+  co2_calibration_date: "Not Set"
   # Automatically controlled Vent
   vent_ha_entity: fan.vent_id
   vent_use_humidity: "true"

--- a/config/sensor-pkg-b-ld2450-stsz-esp32-s3.yaml
+++ b/config/sensor-pkg-b-ld2450-stsz-esp32-s3.yaml
@@ -13,14 +13,14 @@ substitutions:
   co_temp_id: "temperature"
   co_offset: "0.0"
   co_sensitivity: "2.000e-9"
-  co_manufacture_date: "Unknown"
+  co_manufacture_date: "Not Set"
   co_serial_number: "111111111111111111"
   # Temperature Configuration
   temperature_offset: "0.0"
   # Humidity Configuration
   humidity_offset: "0.0"
   # CO₂ Configuration
-  co2_calibration_date: "Unknown"
+  co2_calibration_date: "Not Set"
   # Automatically controlled Vent
   vent_ha_entity: fan.vent_id
   vent_use_humidity: "true"


### PR DESCRIPTION
Changing default value to 'Not Set' makes it clear the sensor is reporting and not just never set or 'Unknown'